### PR TITLE
Fix: Ensure OS is removed from all directories upon finalization

### DIFF
--- a/app.py
+++ b/app.py
@@ -758,14 +758,13 @@ def finalizar_os(os_numero_str):
                 db.session.add(nova_finalizacao)
                 db.session.commit()
                 
-                if diretorio_json_os: 
-                    removidos = remover_os_de_todos_json(diretorio_json_os, os_numero_str)
-                    if removidos: 
-                        flash(f'OS {os_numero_str} removida de: {", ".join(removidos)}', 'info')
-                elif 'gerente' in session:
-                    removidos = remover_os_de_todos_json(MENSAGENS_DIR, os_numero_str)
-                    if removidos: 
-                        flash(f'OS {os_numero_str} removida de arquivos de gerente: {", ".join(removidos)}', 'info')
+                # Garante que a OS seja removida de todos os diretórios relevantes
+                removidos_gerente = remover_os_de_todos_json(MENSAGENS_DIR, os_numero_str)
+                removidos_prestador = remover_os_de_todos_json(MENSAGENS_PRESTADOR_DIR, os_numero_str)
+
+                removidos_todos = list(set(removidos_gerente + removidos_prestador))
+                if removidos_todos:
+                    flash(f'OS {os_numero_str} removida de: {", ".join(removidos_todos)}', 'info')
 
                 flash(f'OS {os_numero_str} finalizada e registrada!', 'success')
         except ValueError as ve:


### PR DESCRIPTION
Previously, when a work order (OS) was finalized, the application would only attempt to remove its corresponding JSON entry from the directory associated with the current user's type (e.g., manager or provider).

This created a bug where an OS finalized by a provider might not be removed from the manager's directory if a copy existed there. This 'orphaned' OS could then reappear for the provider later.

This commit modifies the `finalizar_os` function to be more robust. It now unconditionally attempts to remove the finalized OS from all relevant source directories (`mensagens_por_gerente` and `mensagens_por_prestador`), ensuring the OS is completely purged from the file system, which resolves the bug.