### PR TITLE
feat: Add pending status for service orders

### DIFF
--- a/templates/admin.html
+++ b/templates/admin.html
@@ -410,6 +410,22 @@
             <input type="text" id="date-range" class="flatpickr-input form-control" placeholder="Intervalo de datas" value="{% if data_inicio and data_fim %}{{ data_inicio }} to {{ data_fim }}{% endif %}">
             <input type="text" id="filter-os" class="form-control form-control-sm" placeholder="Filtrar por OS, supervisor ou observações...">
           </div>
+
+          <!-- Filtro de Status -->
+          <div class="mb-3">
+              <strong class="me-2">Filtrar por Status:</strong>
+              <div class="btn-group">
+                  <a href="{{ url_for('admin_panel', periodo=periodo, data_inicio=data_inicio, data_fim=data_fim, filtro_status='todos') }}"
+                     class="btn btn-sm {% if filtro_status == 'todos' %}btn-primary{% else %}btn-outline-primary{% endif %}">
+                      Todas
+                  </a>
+                  <a href="{{ url_for('admin_panel', periodo=periodo, data_inicio=data_inicio, data_fim=data_fim, filtro_status='pendente') }}"
+                     class="btn btn-sm {% if filtro_status == 'pendente' %}btn-warning{% else %}btn-outline-warning{% endif %}">
+                      Pendente <span class="badge bg-danger">{{ os_pendentes_todas|length }}</span>
+                  </a>
+              </div>
+          </div>
+
           <div class="table-responsive">
             <table class="table table-modern table-sm">
               <thead>
@@ -447,8 +463,43 @@
         </div>
       </div>
 
-      <!-- Ranking de OS Pendentes (Supervisores) -->
+      <!-- Tabela de OS Pendentes -->
+      {% if os_pendentes_todas %}
       <div class="card-modern mb-4">
+        <div class="card-header bg-warning text-dark d-flex justify-content-between align-items-center">
+          <h4 class="mb-0"><i class="fas fa-pause-circle icon-agro"></i>Manutenções Pendentes</h4>
+        </div>
+        <div class="card-body">
+          <div class="table-responsive">
+            <table class="table table-modern table-sm table-hover">
+              <thead>
+                <tr>
+                  <th>OS</th>
+                  <th>Frota</th>
+                  <th>Prestador</th>
+                  <th>Motivo da Pendência</th>
+                  <th>Data Status</th>
+                </tr>
+              </thead>
+              <tbody>
+                {% for p in os_pendentes_todas %}
+                <tr>
+                  <td><span class="badge bg-secondary">{{ p.os }}</span></td>
+                  <td>{{ p.frota }}</td>
+                  <td>{{ p.status_definido_por | default('N/A') }}</td>
+                  <td>{{ p.status_motivo | default('N/A') }}</td>
+                  <td>{{ p.status_data | default('N/A') }}</td>
+                </tr>
+                {% endfor %}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+      {% endif %}
+
+      <!-- Ranking de OS Pendentes (Supervisores) -->
+      <div class="card-modern mb-4 {% if filtro_status == 'pendente' %}d-none{% endif %}">
         <div class="card-header ranking-gerentes d-flex justify-content-between align-items-center">
           <h4 class="mb-0"><i class="fas fa-trophy icon-agro"></i>Ranking Manutenções Pendentes (Supervisores)</h4>
           {% if ranking_os_abertas|length > 3 %}
@@ -481,7 +532,7 @@
       </div>
 
       <!-- Ranking de OS Pendentes (Prestadores) -->
-      <div class="card-modern mb-4">
+      <div class="card-modern mb-4 {% if filtro_status == 'pendente' %}d-none{% endif %}">
         <div class="card-header ranking-prestadores d-flex justify-content-between align-items-center">
           <h4 class="mb-0"><i class="fas fa-trophy icon-agro"></i>Ranking Manutenções Pendentes (Prestadores)</h4>
           {% if ranking_os_prestadores|length > 3 %}

--- a/templates/painel.html
+++ b/templates/painel.html
@@ -271,6 +271,38 @@
     </div>
   {% endif %}
 
+  <!-- Seção de OS Pendentes (para todos) -->
+  {% if todas_os_pendentes %}
+  <hr class="my-5">
+  <h2 class="h5 mb-3 text-warning">
+      <i class="fas fa-pause-circle me-2"></i> OS Pendentes (Aguardando Ação)
+  </h2>
+  <div class="table-responsive">
+      <table class="table table-modern table-sm table-hover">
+          <thead class="table-light">
+              <tr>
+                  <th>OS</th>
+                  <th>Frota</th>
+                  <th>Prestador</th>
+                  <th>Motivo da Pendência</th>
+                  <th>Data Status</th>
+              </tr>
+          </thead>
+          <tbody>
+              {% for p in todas_os_pendentes %}
+              <tr>
+                  <td><span class="badge bg-secondary">{{ p.os }}</span></td>
+                  <td>{{ p.frota }}</td>
+                  <td>{{ p.status_definido_por | default('N/A') }}</td>
+                  <td>{{ p.status_motivo | default('N/A') }}</td>
+                  <td>{{ p.status_data | default('N/A') }}</td>
+              </tr>
+              {% endfor %}
+          </tbody>
+      </table>
+  </div>
+  {% endif %}
+
   <hr class="my-5">
   <h2 class="h5 mb-3">
     <i class="fas fa-history me-2 text-primary"></i> Histórico de OS Finalizadas (Últimas 100)

--- a/templates/painel_prestador.html
+++ b/templates/painel_prestador.html
@@ -157,14 +157,29 @@
                     <span style="white-space: pre-wrap;">{{ item.servico | default('Serviço não especificado.') }}</span>
                 </p>
                 
+                {% if item.status == 'Pendente' %}
+                <div class="alert alert-warning p-2" role="alert">
+                    <h6 class="alert-heading h6 mb-1"><i class="fas fa-pause-circle me-1"></i>OS Pendente</h6>
+                    <p class="mb-1 small"><strong>Motivo:</strong> {{ item.status_motivo }}</p>
+                    <p class="small text-muted mb-0">
+                        Definido por: {{ item.status_definido_por }} em {{ item.status_data }}
+                    </p>
+                </div>
+                {% endif %}
+
                 <hr class="form-section-divider">
+
+                <div class="d-flex justify-content-between align-items-center">
+                    <h6 class="finalization-header mb-0"><i class="fas fa-check-square me-1"></i>Finalizar esta OS:</h6>
+                    <button type="button" class="btn btn-outline-warning btn-sm" data-bs-toggle="modal" data-bs-target="#pendenteModal-{{ item.os }}">
+                        <i class="fas fa-pause-circle me-1"></i>Marcar Pendente
+                    </button>
+                </div>
 
                 <form action="{{ url_for('finalizar_os', os_numero_str=item.os) }}"
                       method="POST"
                       enctype="multipart/form-data"
-                      class="needs-validation" novalidate onsubmit="return validateFinalizationForm(this, '{{ item.data_entrada }}')">
-                    
-                    <h6 class="finalization-header"><i class="fas fa-check-square me-1"></i>Finalizar esta OS:</h6>
+                      class="needs-validation mt-3" novalidate onsubmit="return validateFinalizationForm(this, '{{ item.data_entrada }}')">
                     
                     <div class="row g-2 mb-2">
                         <div class="col-md-6">
@@ -230,6 +245,32 @@
                     <div class="modal-footer">
                         <button type="button" class="btn btn-secondary btn-sm" data-bs-dismiss="modal">Fechar</button>
                     </div>
+                </div>
+            </div>
+        </div>
+
+        <!-- Modal para Marcar como Pendente -->
+        <div class="modal fade" id="pendenteModal-{{ item.os }}" tabindex="-1" aria-labelledby="pendenteModalLabel-{{ item.os }}" aria-hidden="true">
+            <div class="modal-dialog modal-dialog-centered">
+                <div class="modal-content">
+                    <form action="{{ url_for('marcar_pendente', os_numero=item.os) }}" method="POST" class="needs-validation" novalidate>
+                        <div class="modal-header bg-warning text-dark">
+                            <h5 class="modal-title" id="pendenteModalLabel-{{ item.os }}"><i class="fas fa-pause-circle me-2"></i>Marcar OS {{ item.os }} como Pendente</h5>
+                            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                        </div>
+                        <div class="modal-body">
+                            <p>A OS ficará com o status "Pendente" e será destacada para o gerente e administrador.</p>
+                            <div class="mb-3">
+                                <label for="motivo_{{ item.os }}" class="form-label"><strong>Motivo da Pendência <span class="text-danger">*</span></strong></label>
+                                <textarea class="form-control" id="motivo_{{ item.os }}" name="motivo" rows="4" placeholder="Ex: Aguardando chegada de peças, Necessário aprovação do cliente, etc." required></textarea>
+                                <div class="invalid-feedback">Por favor, informe o motivo da pendência.</div>
+                            </div>
+                        </div>
+                        <div class="modal-footer">
+                            <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancelar</button>
+                            <button type="submit" class="btn btn-warning text-dark"><i class="fas fa-save me-1"></i>Salvar Pendência</button>
+                        </div>
+                    </form>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
This commit introduces a new 'Pendente' (Pending) status for service orders (OS).

Key features:
- Service providers can now mark an OS as pending and provide a reason (e.g., 'Awaiting parts') through a new modal in their dashboard.
- The pending status, reason, and who set it are now visible on the manager's dashboard in a new dedicated table, ensuring they are aware of blocked tasks.
- The admin dashboard now includes a new table to display all pending OS. A filter has also been added to allow admins to view all open OS or only the pending ones.

This change addresses the need for better status tracking and visibility for OS that are temporarily on hold.