### PR TITLE
fix: Display profile picture upload button on maintenance panel

### DIFF
--- a/app.py
+++ b/app.py
@@ -689,7 +689,8 @@ def painel_manutencao():
                          prestadores_disponiveis=carregar_prestadores(),
                          profile_picture=foto_perfil_manut,
                          now=datetime.now(saopaulo_tz), 
-                         today_date=datetime.now(saopaulo_tz).strftime('%Y-%m-%d'))
+                         today_date=datetime.now(saopaulo_tz).strftime('%Y-%m-%d'),
+                         manutencao=session.get('manutencao'))
 
 @app.route('/finalizar_os/<os_numero_str>', methods=['POST'])
 def finalizar_os(os_numero_str): 


### PR DESCRIPTION
This commit fixes a bug where the 'Change Photo' button was not being displayed on the maintenance panel for users 'arthur' and 'mauricio'.

The issue was caused by the `manutencao` variable (containing the logged-in user's username) not being passed from the `painel_manutencao` route in `app.py` to the `painel_manutencao.html` template. This caused the `if` condition that checks the username to always fail, hiding the upload form.

The fix adds the missing `manutencao=session.get('manutencao')` parameter to the `render_template` call, ensuring the button is now correctly displayed for the intended users.