### PR TITLE
feat: Filter unassigned OS by responsible user in description

### DIFF
--- a/app.py
+++ b/app.py
@@ -420,26 +420,28 @@ def carregar_os_sem_prestador(username_manut=None):
     lista_os_sem_p = []
     data_hoje_sem_p = saopaulo_tz.localize(datetime.now()).date()
 
-    todos_arquivos = os.listdir(MENSAGENS_DIR)
-    arquivos_a_processar = []
-
+    # Prepara o termo de busca se um usuário de manutenção for especificado
+    termo_busca = None
     if username_manut:
-        # Filtra os arquivos para processar apenas aqueles que contêm o nome do usuário de manutenção
-        for nome_arquivo in todos_arquivos:
-            if username_manut.lower() in nome_arquivo.lower() and nome_arquivo.lower().endswith('.json'):
-                arquivos_a_processar.append(nome_arquivo)
-    else:
-        # Comportamento original: processa todos os arquivos JSON
-        arquivos_a_processar = [f for f in todos_arquivos if f.lower().endswith('.json')]
+        # Ex: "Responsavel Sr. Arthur"
+        termo_busca = f"Responsavel Sr. {username_manut}".lower()
 
-    for nome_arquivo_json_gerente in arquivos_a_processar:
-        caminho_arq_gerente = os.path.join(MENSAGENS_DIR, nome_arquivo_json_gerente)
-        try:
-            with open(caminho_arq_gerente, 'r', encoding='utf-8') as f_gerente:
-                dados_os_gerente = json.load(f_gerente)
-            for os_item_g in dados_os_gerente:
+    for nome_arquivo_json_gerente in os.listdir(MENSAGENS_DIR):
+        if nome_arquivo_json_gerente.lower().endswith('.json'):
+            caminho_arq_gerente = os.path.join(MENSAGENS_DIR, nome_arquivo_json_gerente)
+            try:
+                with open(caminho_arq_gerente, 'r', encoding='utf-8') as f_gerente:
+                    dados_os_gerente = json.load(f_gerente)
+                for os_item_g in dados_os_gerente:
                 nome_prestador = str(os_item_g.get('prestador') or os_item_g.get('Prestador', '')).lower().strip()
                 if nome_prestador in ('nan', '', 'none', 'não definido', 'prestador não definido'):
+
+                        servico_str = str(os_item_g.get('servico') or os_item_g.get('Servico') or os_item_g.get('observacao') or os_item_g.get('Observacao', '')).lower()
+
+                        # Se um termo de busca foi definido, filtra com base nele
+                        if termo_busca and termo_busca not in servico_str:
+                            continue # Pula para a próxima OS se não for responsável
+
                     data_os_g_str = str(os_item_g.get('data') or os_item_g.get('Data', ''))
                     data_abertura_os_g = None
                     if data_os_g_str:


### PR DESCRIPTION
This commit implements the correct filtering logic for the maintenance panel's list of unassigned service orders (OS).

The `carregar_os_sem_prestador` function in `app.py` has been updated to filter OS based on a key phrase in the 'servico' (description) field. It now searches for "Responsavel Sr. {username}" to determine which maintenance user is responsible for an unassigned OS.

This replaces a previous, faulty implementation that incorrectly filtered based on filenames. This new approach uses the business logic you provided to ensure that maintenance supervisors like 'Mauricio' and 'Arthur' see only the OS assigned to them, streamlining their workflow.

The function call in the `painel_manutencao` route has been updated to pass the logged-in user's name to enable this filtering.