### PR TITLE
hotfix: Correct IndentationError in carregar_os_sem_prestador

### DIFF
--- a/app.py
+++ b/app.py
@@ -420,10 +420,8 @@ def carregar_os_sem_prestador(username_manut=None):
     lista_os_sem_p = []
     data_hoje_sem_p = saopaulo_tz.localize(datetime.now()).date()
 
-    # Prepara o termo de busca se um usuário de manutenção for especificado
     termo_busca = None
     if username_manut:
-        # Ex: "Responsavel Sr. Arthur"
         termo_busca = f"Responsavel Sr. {username_manut}".lower()
 
     for nome_arquivo_json_gerente in os.listdir(MENSAGENS_DIR):
@@ -433,36 +431,35 @@ def carregar_os_sem_prestador(username_manut=None):
                 with open(caminho_arq_gerente, 'r', encoding='utf-8') as f_gerente:
                     dados_os_gerente = json.load(f_gerente)
                 for os_item_g in dados_os_gerente:
-                nome_prestador = str(os_item_g.get('prestador') or os_item_g.get('Prestador', '')).lower().strip()
-                if nome_prestador in ('nan', '', 'none', 'não definido', 'prestador não definido'):
-
+                    nome_prestador = str(os_item_g.get('prestador') or os_item_g.get('Prestador', '')).lower().strip()
+                    if nome_prestador in ('nan', '', 'none', 'não definido', 'prestador não definido'):
                         servico_str = str(os_item_g.get('servico') or os_item_g.get('Servico') or os_item_g.get('observacao') or os_item_g.get('Observacao', '')).lower()
 
-                        # Se um termo de busca foi definido, filtra com base nele
                         if termo_busca and termo_busca not in servico_str:
-                            continue # Pula para a próxima OS se não for responsável
+                            continue
 
-                    data_os_g_str = str(os_item_g.get('data') or os_item_g.get('Data', ''))
-                    data_abertura_os_g = None
-                    if data_os_g_str:
-                        for fmt_g in ("%d/%m/%Y", "%Y-%m-%d", "%d-%m-%y", "%Y/%m/%d"):
-                            try:
-                                data_abertura_os_g = datetime.strptime(data_os_g_str, fmt_g).date()
-                                break
-                            except (ValueError,TypeError): continue
+                        data_os_g_str = str(os_item_g.get('data') or os_item_g.get('Data', ''))
+                        data_abertura_os_g = None
+                        if data_os_g_str:
+                            for fmt_g in ("%d/%m/%Y", "%Y-%m-%d", "%d-%m-%y", "%Y/%m/%d"):
+                                try:
+                                    data_abertura_os_g = datetime.strptime(data_os_g_str, fmt_g).date()
+                                    break
+                                except (ValueError,TypeError):
+                                    continue
 
-                    dias_abertos_g = (data_hoje_sem_p - data_abertura_os_g).days if data_abertura_os_g else 0
-                    lista_os_sem_p.append({
-                        'os': str(os_item_g.get('os') or os_item_g.get('OS', '')),
-                        'frota': str(os_item_g.get('frota') or os_item_g.get('Frota', '')),
-                        'data_entrada': data_os_g_str,
-                        'modelo': str(os_item_g.get('modelo') or os_item_g.get('Modelo', 'Desconhecido') or 'Desconhecido'),
-                        'servico': str(os_item_g.get('servico') or os_item_g.get('Servico') or os_item_g.get('observacao') or os_item_g.get('Observacao', '')),
-                        'arquivo_origem': nome_arquivo_json_gerente,
-                        'dias_abertos': dias_abertos_g
-                    })
-        except Exception as e:
-            logger.error(f"Erro ao carregar OS sem prestador de {caminho_arq_gerente}: {e}")
+                        dias_abertos_g = (data_hoje_sem_p - data_abertura_os_g).days if data_abertura_os_g else 0
+                        lista_os_sem_p.append({
+                            'os': str(os_item_g.get('os') or os_item_g.get('OS', '')),
+                            'frota': str(os_item_g.get('frota') or os_item_g.get('Frota', '')),
+                            'data_entrada': data_os_g_str,
+                            'modelo': str(os_item_g.get('modelo') or os_item_g.get('Modelo', 'Desconhecido') or 'Desconhecido'),
+                            'servico': str(os_item_g.get('servico') or os_item_g.get('Servico') or os_item_g.get('observacao') or os_item_g.get('Observacao', '')),
+                            'arquivo_origem': nome_arquivo_json_gerente,
+                            'dias_abertos': dias_abertos_g
+                        })
+            except Exception as e:
+                logger.error(f"Erro ao carregar OS sem prestador de {caminho_arq_gerente}: {e}")
     return lista_os_sem_p
 
 # --- Rotas ---


### PR DESCRIPTION
This commit provides a definitive fix for a recurring `IndentationError` in the `carregar_os_sem_prestador` function in `app.py`.

Previous attempts to modify this function resulted in incorrect whitespace, causing the Python syntax to be invalid and blocking application deployment.

This change replaces the entire function with a correctly formatted version, ensuring that the indentation is valid and the deployment can proceed successfully. The underlying logic for filtering unassigned OS by the responsible user in the description remains the same as the last feature implementation.