### PR TITLE
feat: Add charts tab and personalize greeting on admin panel

### DIFF
--- a/templates/admin.html
+++ b/templates/admin.html
@@ -401,7 +401,7 @@
   <div class="mascot-container">
     <div class="mascot-icon">🚜</div>
     <div class="speech-bubble {{ bubble_class }}">
-      <h5 class="fw-bold mb-1">{{ random_greeting }} Admin!</h5>
+      <h5 class="fw-bold mb-1">{{ random_greeting }} {{ session.get('gerente')|capitalize_name }}!</h5>
       <p class="mb-0">{{ message }}</p>
     </div>
   </div>
@@ -418,6 +418,11 @@
       <a href="{{ url_for('frota_leve') }}" class="nav-link">
         <i class="fas fa-car-side icon-agro"></i>Frota Leve
       </a>
+    </li>
+    <li class="nav-item" role="presentation">
+      <button class="nav-link" id="charts-tab" data-bs-toggle="tab" data-bs-target="#charts" type="button" role="tab" aria-controls="charts" aria-selected="false">
+        <i class="fas fa-chart-pie me-1"></i>Análises
+      </button>
     </li>
   </ul>
 
@@ -642,6 +647,37 @@
         </div>
       </div>
     </div>
+
+    <!-- Aba: Análises Gráficas -->
+    <div class="tab-pane fade" id="charts" role="tabpanel" aria-labelledby="charts-tab">
+      <div class="row">
+        <div class="col-lg-6 mb-4">
+          <div class="card-modern">
+            <div class="card-header">
+              <h4 class="mb-0"><i class="fas fa-chart-bar me-2"></i>Manutenções por Período</h4>
+            </div>
+            <div class="card-body">
+              <div class="chart-container">
+                <canvas id="osPorPeriodo"></canvas>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="col-lg-6 mb-4">
+          <div class="card-modern">
+            <div class="card-header">
+              <h4 class="mb-0"><i class="fas fa-chart-pie me-2"></i>Manutenções por Supervisor</h4>
+            </div>
+            <div class="card-body">
+              <div class="chart-container">
+                <canvas id="osPorGerente"></canvas>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
   </div>
 </div>
 {% endblock %}


### PR DESCRIPTION
This commit introduces two improvements to the admin dashboard (`admin.html`) based on user feedback:

1.  **Personalized Greeting:** The mascot's greeting message now dynamically displays the logged-in admin's name (e.g., "Olá, Wilson Santana!") instead of a static "Admin".
2.  **'Análises' Tab:** A new tab labeled 'Análises' has been added to the dashboard. This tab contains the data visualization charts for 'Manutenções por Período' and 'Manutenções por Supervisor', making them accessible and organized.

These changes enhance the personalization and data visualization capabilities of the admin panel.