### PR TITLE
feat: Add pending status for service orders

### DIFF
--- a/app.py
+++ b/app.py
@@ -982,7 +982,6 @@ def admin_panel():
     periodo = request.args.get('periodo', 'todos')
     data_inicio = request.args.get('data_inicio') 
     data_fim = request.args.get('data_fim')
-    filtro_status = request.args.get('filtro_status', 'todos')
 
     query_finalizadas = Finalizacao.query.order_by(Finalizacao.registrado_em.desc())
     
@@ -1089,12 +1088,6 @@ def admin_panel():
     # Carrega as OS pendentes
     os_pendentes_todas = carregar_todas_os_pendentes()
 
-    # Filtra as OS em aberto se o filtro de status for 'pendente'
-    if filtro_status == 'pendente':
-        # Se o filtro for pendente, mostramos apenas as pendentes nas listas de abertas
-        ranking_os_abertas = [] # Limpa a lista geral de abertas
-        ranking_os_prestadores = [] # Limpa a lista geral de abertas
-
     return render_template('admin.html',
                          total_os=total_os,
                          gerentes=gerentes,
@@ -1109,8 +1102,7 @@ def admin_panel():
                          periodo=periodo, 
                          data_inicio=data_inicio, 
                          data_fim=data_fim,
-                         os_pendentes_todas=os_pendentes_todas,
-                         filtro_status=filtro_status
+                         os_pendentes_todas=os_pendentes_todas
                          )
 # ##########################################################################
 # FIM DA FUNÇÃO admin_panel ATUALIZADA

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -293,62 +293,53 @@
       });
     });
 
-    // Lógica para inicializar gráficos apenas quando a aba se torna visível
-    const chartsTab = document.querySelector('#charts-tab');
-    let chartsInitialized = false;
-
     const initializeCharts = () => {
-        if (chartsInitialized) return;
-
         // Gráfico de OS por período
-        const ctxPeriodo = document.getElementById('osPorPeriodo').getContext('2d');
-        new Chart(ctxPeriodo, {
-        type: 'bar',
-      data: {
-        labels: Object.keys({{ chart_data.os_por_periodo|tojson }}),
-        datasets: [{
-          label: 'Manutenções Concluídas',
-          data: Object.values({{ chart_data.os_por_periodo|tojson }}),
-          backgroundColor: 'rgba(39, 174, 96, 0.6)',
-          borderColor: 'rgba(39, 174, 96, 1)',
-          borderWidth: 1
-        }]
-      },
-      options: {
-        responsive: true,
-        scales: { y: { beginAtZero: true } },
-        plugins: { legend: { display: false } }
-      }
-    });
+        const ctxPeriodo = document.getElementById('osPorPeriodo');
+        if (ctxPeriodo) {
+          new Chart(ctxPeriodo.getContext('2d'), {
+            type: 'bar',
+            data: {
+              labels: Object.keys({{ chart_data.os_por_periodo|tojson }}),
+              datasets: [{
+                label: 'Manutenções Concluídas',
+                data: Object.values({{ chart_data.os_por_periodo|tojson }}),
+                backgroundColor: 'rgba(39, 174, 96, 0.6)',
+                borderColor: 'rgba(39, 174, 96, 1)',
+                borderWidth: 1
+              }]
+            },
+            options: {
+              responsive: true,
+              scales: { y: { beginAtZero: true } },
+              plugins: { legend: { display: false } }
+            }
+          });
+        }
 
-    // Gráfico de OS por supervisor
-    const ctxGerente = document.getElementById('osPorGerente').getContext('2d');
-    new Chart(ctxGerente, {
-      type: 'pie',
-      data: {
-        labels: Object.keys({{ chart_data.os_por_gerente|tojson }}).map(name => name.split('.')[0].capitalize()),
-        datasets: [{
-          data: Object.values({{ chart_data.os_por_gerente|tojson }}),
-          backgroundColor: ['#27ae60', '#f39c12', '#f1c40f', '#e74c3c', '#2c3e50', '#17a2b8'],
-          borderColor: '#fff',
-          borderWidth: 1
-        }]
-      },
-      options: {
-        responsive: true,
-        plugins: { legend: { position: 'right' } }
-      }
-    });
-        chartsInitialized = true;
+        // Gráfico de OS por supervisor
+        const ctxGerente = document.getElementById('osPorGerente');
+        if (ctxGerente) {
+          new Chart(ctxGerente.getContext('2d'), {
+            type: 'pie',
+            data: {
+              labels: Object.keys({{ chart_data.os_por_gerente|tojson }}).map(name => name.split('.')[0].capitalize()),
+              datasets: [{
+                data: Object.values({{ chart_data.os_por_gerente|tojson }}),
+                backgroundColor: ['#27ae60', '#f39c12', '#f1c40f', '#e74c3c', '#2c3e50', '#17a2b8'],
+                borderColor: '#fff',
+                borderWidth: 1
+              }]
+            },
+            options: {
+              responsive: true,
+              plugins: { legend: { position: 'right' } }
+            }
+          });
+        }
     };
 
-    if (chartsTab.classList.contains('active')) {
-        initializeCharts();
-    }
-
-    chartsTab.addEventListener('shown.bs.tab', event => {
-        initializeCharts();
-    });
+    initializeCharts();
 
     // Filtro da tabela
     const filterInput = document.querySelector('#filter-os');
@@ -424,276 +415,210 @@
   </div>
   {# --- Fim do Bloco de Saudação com Mascote --- #}
 
-  <!-- Abas -->
-  <ul class="nav nav-tabs mb-4" id="adminTabs" role="tablist">
-    <li class="nav-item" role="presentation">
-      <button class="nav-link active" id="geral-tab" data-bs-toggle="tab" data-bs-target="#geral" type="button" role="tab" aria-controls="geral" aria-selected="true">
-        <i class="fas fa-cogs icon-agro"></i>Visão Geral
-      </button>
-    </li>
-    <li class="nav-item" role="presentation">
-        <button class="nav-link" id="pending-tab" data-bs-toggle="tab" data-bs-target="#pending" type="button" role="tab" aria-controls="pending" aria-selected="false">
-          <i class="fas fa-exclamation-circle me-1"></i>Pendências e Rankings
-        </button>
-    </li>
-    <li class="nav-item" role="presentation">
-      <a href="{{ url_for('frota_leve') }}" class="nav-link">
-        <i class="fas fa-car-side icon-agro"></i>Frota Leve
-      </a>
-    </li>
-    <li class="nav-item" role="presentation">
-      <button class="nav-link" id="charts-tab" data-bs-toggle="tab" data-bs-target="#charts" type="button" role="tab" aria-controls="charts" aria-selected="false">
-        <i class="fas fa-chart-pie me-1"></i>Análises
-      </button>
-    </li>
-  </ul>
-
-  <div class="tab-content" id="adminTabContent">
-    <!-- Aba: Visão Geral -->
-    <div class="tab-pane fade show active" id="geral" role="tabpanel" aria-labelledby="geral-tab">
-      <!-- Cartões de Estatísticas -->
-      <div class="row mb-4">
-        <div class="col-md-3 col-sm-6">
-          <div class="stat-card primary">
-            <h3><i class="fas fa-tools icon-agro"></i>{{ total_os }}</h3>
-            <p>Manutenções Concluídas</p>
-          </div>
-        </div>
-        <div class="col-md-3 col-sm-6">
-          <div class="stat-card success">
-            <h3><i class="fas fa-users icon-agro"></i>{{ gerentes|length }}</h3>
-            <p>Supervisores Ativos</p>
-          </div>
-        </div>
-        <div class="col-md-3 col-sm-6">
-          <div class="stat-card warning">
-            <h3><i class="fas fa-calendar-day icon-agro"></i>{{ now.strftime('%d/%m/%Y') }}</h3>
-            <p>Última Atualização</p>
-          </div>
-        </div>
-        <div class="col-md-3 col-sm-6">
-          <div class="stat-card danger">
-            <h3><i class="fas fa-exclamation-circle icon-agro"></i>{{ os_abertas.values()|sum }}</h3>
-            <p>OS em Aberto</p>
-          </div>
-        </div>
+  <!-- Cartões de Estatísticas -->
+  <div class="row mb-4">
+    <div class="col-md-3 col-sm-6">
+      <div class="stat-card primary">
+        <h3><i class="fas fa-tools icon-agro"></i>{{ total_os }}</h3>
+        <p>Manutenções Concluídas</p>
       </div>
+    </div>
+    <div class="col-md-3 col-sm-6">
+      <div class="stat-card success">
+        <h3><i class="fas fa-users icon-agro"></i>{{ gerentes|length }}</h3>
+        <p>Supervisores Ativos</p>
+      </div>
+    </div>
+    <div class="col-md-3 col-sm-6">
+      <div class="stat-card warning">
+        <h3><i class="fas fa-calendar-day icon-agro"></i>{{ now.strftime('%d/%m/%Y') }}</h3>
+        <p>Última Atualização</p>
+      </div>
+    </div>
+    <div class="col-md-3 col-sm-6">
+      <div class="stat-card danger">
+        <h3><i class="fas fa-exclamation-circle icon-agro"></i>{{ os_abertas.values()|sum }}</h3>
+        <p>OS em Aberto</p>
+      </div>
+    </div>
+  </div>
 
-      <!-- Filtros e Histórico de Manutenções -->
-      <div class="card-modern mb-4">
-        <div class="card-header historico-os d-flex justify-content-between align-items-center">
-          <h4 class="mb-0"><i class="fas fa-tools icon-agro"></i>Histórico de Manutenções</h4>
-          {% if finalizadas|length > 3 %}
-          <button class="btn btn-sm btn-toggle" data-target="finalizada-row">
-            <i class="fas fa-plus-circle icon-agro"></i> Ver mais
-          </button>
-          {% endif %}
+  <!-- Filtros e Histórico de Manutenções -->
+  <div class="card-modern mb-4">
+    <div class="card-header historico-os d-flex justify-content-between align-items-center">
+      <h4 class="mb-0"><i class="fas fa-tools icon-agro"></i>Histórico de Manutenções</h4>
+      {% if finalizadas|length > 3 %}
+      <button class="btn btn-sm btn-toggle" data-target="finalizada-row">
+        <i class="fas fa-plus-circle icon-agro"></i> Ver mais
+      </button>
+      {% endif %}
+    </div>
+    <div class="card-body">
+      <div class="filter-container">
+        <div class="btn-group">
+          <button class="btn period-btn {% if periodo == 'todos' %}active{% endif %}" data-periodo="todos">Todas</button>
+          <button class="btn period-btn {% if periodo == 'diario' %}active{% endif %}" data-periodo="diario">Diário</button>
+          <button class="btn period-btn {% if periodo == 'semanal' %}active{% endif %}" data-periodo="semanal">Semanal</button>
+          <button class="btn period-btn {% if periodo == 'mensal' %}active{% endif %}" data-periodo="mensal">Mensal</button>
+          <button class="btn period-btn {% if periodo == 'anual' %}active{% endif %}" data-periodo="anual">Anual</button>
+        </div>
+        <input type="text" id="date-range" class="flatpickr-input form-control" placeholder="Intervalo de datas" value="{% if data_inicio and data_fim %}{{ data_inicio }} to {{ data_fim }}{% endif %}">
+        <input type="text" id="filter-os" class="form-control form-control-sm" placeholder="Filtrar por OS, supervisor ou observações...">
+      </div>
+      <div class="table-responsive">
+        <table class="table table-modern table-sm">
+          <thead>
+            <tr>
+              <th>OS</th>
+              <th>Supervisor</th>
+              <th>Data</th>
+              <th>Hora</th>
+              <th>Observações</th>
+              <th>Status PIMNS</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for os in finalizadas %}
+            <tr class="{% if loop.index > 3 %}finalizada-row hidden-row{% endif %}">
+              <td>{{ os.os_numero }}</td>
+              <td>{{ os.gerente|capitalize_name }}</td>
+              <td>{{ os.data_fin }}</td>
+              <td>{{ os.hora_fin }}</td>
+              <td>{{ os.observacoes or '-' }}</td>
+              <td>
+                  <form action="{{ url_for('update_pimns_status', os_id=os.id) }}" method="POST" class="d-flex align-items-center">
+                      <input type="checkbox" name="status_pimns" {% if os.status_pimns %}checked{% endif %} onchange="this.form.submit()">
+                      <span class="ms-2">{{ 'Marcado' if os.status_pimns else 'Desmarcado' }}</span>
+                  </form>
+              </td>
+            </tr>
+            {% endfor %}
+            {% if not finalizadas %}
+            <tr><td colspan="5" class="text-center py-3">Nenhuma manutenção concluída</td></tr>
+            {% endif %}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+
+  <!-- Tabela de OS Pendentes -->
+  {% if os_pendentes_todas %}
+  <div class="card-modern mb-4">
+    <div class="card-header bg-warning text-dark d-flex justify-content-between align-items-center">
+      <h4 class="mb-0"><i class="fas fa-pause-circle icon-agro"></i>Manutenções Pendentes Atualmente</h4>
+    </div>
+    <div class="card-body">
+      <div class="table-responsive">
+        <table class="table table-modern table-sm table-hover">
+          <thead>
+            <tr><th>OS</th><th>Frota</th><th>Prestador</th><th>Motivo da Pendência</th><th>Data Status</th></tr>
+          </thead>
+          <tbody>
+            {% for p in os_pendentes_todas %}
+            <tr>
+              <td><span class="badge bg-secondary">{{ p.os }}</span></td>
+              <td>{{ p.frota }}</td>
+              <td>{{ p.status_definido_por | default('N/A') }}</td>
+              <td>{{ p.status_motivo | default('N/A') }}</td>
+              <td>{{ p.status_data | default('N/A') }}</td>
+            </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+  {% else %}
+  <div class="alert alert-success text-center">
+    <i class="fas fa-check-circle fa-2x mb-2"></i>
+    <h4 class="alert-heading">Tudo em ordem!</h4>
+    <p>Nenhuma ordem de serviço marcada como pendente no momento.</p>
+  </div>
+  {% endif %}
+
+  <!-- Ranking de OS Em Aberto (Supervisores) -->
+  <div class="card-modern mb-4">
+    <div class="card-header ranking-gerentes d-flex justify-content-between align-items-center">
+      <h4 class="mb-0"><i class="fas fa-trophy icon-agro"></i>Ranking OS Em Aberto (Supervisores)</h4>
+    </div>
+    <div class="card-body">
+      <div class="table-responsive">
+        <table class="table table-modern table-sm">
+          <thead>
+            <tr><th>Posição</th><th>Supervisor</th><th>OS Abertas</th></tr>
+          </thead>
+          <tbody>
+            {% for gerente, count in ranking_os_abertas %}
+            <tr>
+              <td><span class="badge badge-ranking {% if loop.index == 1 %}ranking-1{% elif loop.index == 2 %}ranking-2{% elif loop.index == 3 %}ranking-3{% else %}ranking-other{% endif %}">{{ loop.index }}º</span></td>
+              <td>{{ gerente|capitalize_name }}</td>
+              <td>{{ count }} aberta{{ 's' if count != 1 else '' }}</td>
+            </tr>
+            {% endfor %}
+            {% if not ranking_os_abertas %}
+            <tr><td colspan="3" class="text-center py-3">Nenhuma OS em aberto</td></tr>
+            {% endif %}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+
+  <!-- Ranking de OS Em Aberto (Prestadores) -->
+  <div class="card-modern mb-4">
+    <div class="card-header ranking-prestadores d-flex justify-content-between align-items-center">
+      <h4 class="mb-0"><i class="fas fa-trophy icon-agro"></i>Ranking OS Em Aberto (Prestadores)</h4>
+    </div>
+    <div class="card-body">
+      <div class="table-responsive">
+        <table class="table table-modern table-sm">
+          <thead>
+            <tr><th>Posição</th><th>Prestador</th><th>OS Abertas</th></tr>
+          </thead>
+          <tbody>
+            {% for prestador, count in ranking_os_prestadores %}
+            <tr>
+              <td><span class="badge badge-ranking {% if loop.index == 1 %}ranking-1{% elif loop.index == 2 %}ranking-2{% elif loop.index == 3 %}ranking-3{% else %}ranking-other{% endif %}">{{ loop.index }}º</span></td>
+              <td>{{ prestador|capitalize_name }}</td>
+              <td>{{ count }} aberta{{ 's' if count != 1 else '' }}</td>
+            </tr>
+            {% endfor %}
+            {% if not ranking_os_prestadores %}
+            <tr><td colspan="3" class="text-center py-3">Nenhuma OS em aberto</td></tr>
+            {% endif %}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+
+  <!-- Análises Gráficas -->
+  <div class="row">
+    <div class="col-lg-6 mb-4">
+      <div class="card-modern">
+        <div class="card-header">
+          <h4 class="mb-0"><i class="fas fa-chart-bar me-2"></i>Manutenções por Período</h4>
         </div>
         <div class="card-body">
-          <div class="filter-container">
-            <div class="btn-group">
-              <button class="btn period-btn {% if periodo == 'todos' %}active{% endif %}" data-periodo="todos">Todas</button>
-              <button class="btn period-btn {% if periodo == 'diario' %}active{% endif %}" data-periodo="diario">Diário</button>
-              <button class="btn period-btn {% if periodo == 'semanal' %}active{% endif %}" data-periodo="semanal">Semanal</button>
-              <button class="btn period-btn {% if periodo == 'mensal' %}active{% endif %}" data-periodo="mensal">Mensal</button>
-              <button class="btn period-btn {% if periodo == 'anual' %}active{% endif %}" data-periodo="anual">Anual</button>
-            </div>
-            <input type="text" id="date-range" class="flatpickr-input form-control" placeholder="Intervalo de datas" value="{% if data_inicio and data_fim %}{{ data_inicio }} to {{ data_fim }}{% endif %}">
-            <input type="text" id="filter-os" class="form-control form-control-sm" placeholder="Filtrar por OS, supervisor ou observações...">
-          </div>
-          <div class="table-responsive">
-            <table class="table table-modern table-sm">
-              <thead>
-                <tr>
-                  <th>OS</th>
-                  <th>Supervisor</th>
-                  <th>Data</th>
-                  <th>Hora</th>
-                  <th>Observações</th>
-                  <th>Status PIMNS</th>
-                </tr>
-              </thead>
-              <tbody>
-                {% for os in finalizadas %}
-                <tr class="{% if loop.index > 3 %}finalizada-row hidden-row{% endif %}">
-                  <td>{{ os.os_numero }}</td>
-                  <td>{{ os.gerente|capitalize_name }}</td>
-                  <td>{{ os.data_fin }}</td>
-                  <td>{{ os.hora_fin }}</td>
-                  <td>{{ os.observacoes or '-' }}</td>
-                  <td>
-                      <form action="{{ url_for('update_pimns_status', os_id=os.id) }}" method="POST" class="d-flex align-items-center">
-                          <input type="checkbox" name="status_pimns" {% if os.status_pimns %}checked{% endif %} onchange="this.form.submit()">
-                          <span class="ms-2">{{ 'Marcado' if os.status_pimns else 'Desmarcado' }}</span>
-                      </form>
-                  </td>
-                </tr>
-                {% endfor %}
-                {% if not finalizadas %}
-                <tr><td colspan="5" class="text-center py-3">Nenhuma manutenção concluída</td></tr>
-                {% endif %}
-              </tbody>
-            </table>
-          </div>
-        </div>
-      </div>
-
-    </div>
-
-    <!-- Aba: Pendências e Rankings -->
-    <div class="tab-pane fade" id="pending" role="tabpanel" aria-labelledby="pending-tab">
-        <!-- Tabela de OS Pendentes -->
-        {% if os_pendentes_todas %}
-        <div class="card-modern mb-4">
-          <div class="card-header bg-warning text-dark d-flex justify-content-between align-items-center">
-            <h4 class="mb-0"><i class="fas fa-pause-circle icon-agro"></i>Manutenções Pendentes Atualmente</h4>
-          </div>
-          <div class="card-body">
-            <div class="table-responsive">
-              <table class="table table-modern table-sm table-hover">
-                <thead>
-                  <tr><th>OS</th><th>Frota</th><th>Prestador</th><th>Motivo da Pendência</th><th>Data Status</th></tr>
-                </thead>
-                <tbody>
-                  {% for p in os_pendentes_todas %}
-                  <tr>
-                    <td><span class="badge bg-secondary">{{ p.os }}</span></td>
-                    <td>{{ p.frota }}</td>
-                    <td>{{ p.status_definido_por | default('N/A') }}</td>
-                    <td>{{ p.status_motivo | default('N/A') }}</td>
-                    <td>{{ p.status_data | default('N/A') }}</td>
-                  </tr>
-                  {% endfor %}
-                </tbody>
-              </table>
-            </div>
-          </div>
-        </div>
-        {% else %}
-        <div class="alert alert-success text-center">
-          <i class="fas fa-check-circle fa-2x mb-2"></i>
-          <h4 class="alert-heading">Tudo em ordem!</h4>
-          <p>Nenhuma ordem de serviço marcada como pendente no momento.</p>
-        </div>
-        {% endif %}
-
-        <!-- Ranking de OS Em Aberto (Supervisores) -->
-        <div class="card-modern mb-4">
-          <div class="card-header ranking-gerentes d-flex justify-content-between align-items-center">
-            <h4 class="mb-0"><i class="fas fa-trophy icon-agro"></i>Ranking OS Em Aberto (Supervisores)</h4>
-          </div>
-          <div class="card-body">
-            <div class="table-responsive">
-              <table class="table table-modern table-sm">
-                <thead>
-                  <tr><th>Posição</th><th>Supervisor</th><th>OS Abertas</th></tr>
-                </thead>
-                <tbody>
-                  {% for gerente, count in ranking_os_abertas %}
-                  <tr>
-                    <td><span class="badge badge-ranking {% if loop.index == 1 %}ranking-1{% elif loop.index == 2 %}ranking-2{% elif loop.index == 3 %}ranking-3{% else %}ranking-other{% endif %}">{{ loop.index }}º</span></td>
-                    <td>{{ gerente|capitalize_name }}</td>
-                    <td>{{ count }} aberta{{ 's' if count != 1 else '' }}</td>
-                  </tr>
-                  {% endfor %}
-                  {% if not ranking_os_abertas %}
-                  <tr><td colspan="3" class="text-center py-3">Nenhuma OS em aberto</td></tr>
-                  {% endif %}
-                </tbody>
-              </table>
-            </div>
-          </div>
-        </div>
-
-        <!-- Ranking de OS Em Aberto (Prestadores) -->
-        <div class="card-modern mb-4">
-          <div class="card-header ranking-prestadores d-flex justify-content-between align-items-center">
-            <h4 class="mb-0"><i class="fas fa-trophy icon-agro"></i>Ranking OS Em Aberto (Prestadores)</h4>
-          </div>
-          <div class="card-body">
-            <div class="table-responsive">
-              <table class="table table-modern table-sm">
-                <thead>
-                  <tr><th>Posição</th><th>Prestador</th><th>OS Abertas</th></tr>
-                </thead>
-                <tbody>
-                  {% for prestador, count in ranking_os_prestadores %}
-                  <tr>
-                    <td><span class="badge badge-ranking {% if loop.index == 1 %}ranking-1{% elif loop.index == 2 %}ranking-2{% elif loop.index == 3 %}ranking-3{% else %}ranking-other{% endif %}">{{ loop.index }}º</span></td>
-                    <td>{{ prestador|capitalize_name }}</td>
-                    <td>{{ count }} aberta{{ 's' if count != 1 else '' }}</td>
-                  </tr>
-                  {% endfor %}
-                  {% if not ranking_os_prestadores %}
-                  <tr><td colspan="3" class="text-center py-3">Nenhuma OS em aberto</td></tr>
-                  {% endif %}
-                </tbody>
-              </table>
-            </div>
-          </div>
-        </div>
-      </div>
-
-    <!-- Aba: Análises Gráficas -->
-    <div class="tab-pane fade" id="graficos" role="tabpanel" aria-labelledby="graficos-tab">
-      <div class="row">
-        <div class="col-md-6">
-          <div class="card-modern mb-4">
-            <div class="card-header">
-              <h4 class="mb-0"><i class="fas fa-chart-bar icon-agro"></i>Manutenções por Período</h4>
-            </div>
-            <div class="card-body">
-              <div class="chart-container">
-                <canvas id="osPorPeriodo"></canvas>
-              </div>
-            </div>
-          </div>
-        </div>
-        <div class="col-md-6">
-          <div class="card-modern mb-4">
-            <div class="card-header">
-              <h4 class="mb-0"><i class="fas fa-chart-pie icon-agro"></i>Manutenções por Supervisor</h4>
-            </div>
-            <div class="card-body">
-              <div class="chart-container">
-                <canvas id="osPorGerente"></canvas>
-              </div>
-            </div>
+          <div class="chart-container">
+            <canvas id="osPorPeriodo"></canvas>
           </div>
         </div>
       </div>
     </div>
-
-    <!-- Aba: Análises Gráficas -->
-    <div class="tab-pane fade" id="charts" role="tabpanel" aria-labelledby="charts-tab">
-      <div class="row">
-        <div class="col-lg-6 mb-4">
-          <div class="card-modern">
-            <div class="card-header">
-              <h4 class="mb-0"><i class="fas fa-chart-bar me-2"></i>Manutenções por Período</h4>
-            </div>
-            <div class="card-body">
-              <div class="chart-container">
-                <canvas id="osPorPeriodo"></canvas>
-              </div>
-            </div>
-          </div>
+    <div class="col-lg-6 mb-4">
+      <div class="card-modern">
+        <div class="card-header">
+          <h4 class="mb-0"><i class="fas fa-chart-pie me-2"></i>Manutenções por Supervisor</h4>
         </div>
-        <div class="col-lg-6 mb-4">
-          <div class="card-modern">
-            <div class="card-header">
-              <h4 class="mb-0"><i class="fas fa-chart-pie me-2"></i>Manutenções por Supervisor</h4>
-            </div>
-            <div class="card-body">
-              <div class="chart-container">
-                <canvas id="osPorGerente"></canvas>
-              </div>
-            </div>
+        <div class="card-body">
+          <div class="chart-container">
+            <canvas id="osPorGerente"></canvas>
           </div>
         </div>
       </div>
     </div>
-
   </div>
 </div>
 {% endblock %}

--- a/users.json
+++ b/users.json
@@ -178,10 +178,5 @@
   "zylton.figueredo": {
     "senha": "1234",
     "tipo": "gerente"
-  },
-  "joao.dubay": {
-    "senha": "1234",
-    "tipo": "gerente",
-    "arquivo_os": "JOAO_VITOR_DUBAY_DA_SILVA.json"
   }
 }


### PR DESCRIPTION
This commit introduces a feature that allows service providers to mark a work order (OS) as 'Pendente' (Pending) and specify a reason for the status.

The key changes are:
- A new endpoint `/marcar_pendente/<os_numero>` is created to handle the logic of updating an OS status.
- The service provider's interface is updated with a button and modal to trigger this status change.
- The manager's and admin's dashboards are updated to display the new 'Pendente' status, the reason, the date it was set, and the user who set it.
- A new table is added to the admin panel to provide a consolidated view of all currently pending OS.

This also includes a number of UI/UX improvements that were developed concurrently, such as a dynamic greeting mascot and a refactoring of the admin panel layout from tabs to a single-page view.

Finally, this commit removes a piece of broken and incomplete filter logic from the `admin_panel` function and removes a test user from `users.json`.