### PR TITLE
fix(manutencao): Correct unassigned OS logic and add finalize option

### DIFF
--- a/app.py
+++ b/app.py
@@ -478,14 +478,9 @@ def carregar_todas_os_pendentes():
                     logger.error(f"Erro ao ler arquivo de OS pendente {caminho_arquivo}: {e}")
     return lista_os_pendentes
 
-def carregar_os_sem_prestador(username_manut=None):
+def carregar_os_sem_prestador():
     lista_os_sem_p = []
     data_hoje_sem_p = saopaulo_tz.localize(datetime.now()).date()
-
-    termo_busca_regex = None
-    if username_manut:
-        # Using regex for a more robust, case-insensitive search
-        termo_busca_regex = re.compile(f"Responsavel Sr. {re.escape(username_manut)}", re.IGNORECASE)
 
     for nome_arquivo_json_gerente in os.listdir(MENSAGENS_DIR):
         if nome_arquivo_json_gerente.lower().endswith('.json'):
@@ -497,11 +492,6 @@ def carregar_os_sem_prestador(username_manut=None):
                     nome_prestador = str(os_item_g.get('prestador') or os_item_g.get('Prestador', '')).lower().strip()
                     if nome_prestador in ('nan', '', 'none', 'não definido', 'prestador não definido'):
                         servico_str = str(os_item_g.get('servico') or os_item_g.get('Servico') or os_item_g.get('observacao') or os_item_g.get('Observacao', ''))
-
-                        # If we have a search term, and it's not found in the service string, skip this OS
-                        if termo_busca_regex and not termo_busca_regex.search(servico_str):
-                            continue
-
                         data_os_g_str = str(os_item_g.get('data') or os_item_g.get('Data', ''))
                         data_abertura_os_g = None
                         if data_os_g_str:
@@ -518,7 +508,7 @@ def carregar_os_sem_prestador(username_manut=None):
                             'frota': str(os_item_g.get('frota') or os_item_g.get('Frota', '')),
                             'data_entrada': data_os_g_str,
                             'modelo': str(os_item_g.get('modelo') or os_item_g.get('Modelo', 'Desconhecido') or 'Desconhecido'),
-                            'servico': servico_str, # Use the original case servico_str
+                            'servico': servico_str,
                             'arquivo_origem': nome_arquivo_json_gerente,
                             'dias_abertos': dias_abertos_g
                         })
@@ -714,7 +704,7 @@ def painel_manutencao():
         return redirect(url_for('login'))
 
     lista_os_manutencao = carregar_os_manutencao(session['manutencao'])
-    lista_os_sem_p_manut = carregar_os_sem_prestador(session['manutencao'])
+    lista_os_sem_p_manut = carregar_os_sem_prestador()
     
     ordenar_por = request.args.get('ordenar', 'data_desc')
     if lista_os_manutencao: 

--- a/templates/painel_manutencao.html
+++ b/templates/painel_manutencao.html
@@ -137,7 +137,29 @@
                         <h5 class="card-title mb-2"><span class="badge badge-os">OS {{ os.os }}</span> Frota {{ os.frota }}</h5>
                         <p class="card-text"><small class="text-muted">Abertura: {{ os.data_entrada }} (Aberta há {{ os.dias_abertos }} dias)</small></p>
                         <p class="card-text">{{ os.servico }}</p>
-                        <!-- Finalization Form -->
+                        <hr>
+                        <div class="finalize-section">
+                            <form action="{{ url_for('finalizar_os', os_numero_str=os.os) }}" method="POST">
+                                <div class="row g-2 mb-2">
+                                    <div class="col-md-4">
+                                        <label class="form-label small">Data Finalização</label>
+                                        <input type="date" class="form-control form-control-sm" name="data_finalizacao" required max="{{ today_date }}">
+                                    </div>
+                                    <div class="col-md-3">
+                                        <label class="form-label small">Hora</label>
+                                        <input type="time" class="form-control form-control-sm" name="hora_finalizacao" required>
+                                    </div>
+                                    <div class="col-md-5">
+                                        <label class="form-label small d-block">&nbsp;</label>
+                                        <button type="submit" class="btn btn-agro btn-sm w-100">Finalizar OS</button>
+                                    </div>
+                                </div>
+                                <div class="mt-2">
+                                    <label class="form-label small">Observações</label>
+                                    <textarea class="form-control form-control-sm" name="observacoes" rows="2"></textarea>
+                                </div>
+                            </form>
+                        </div>
                     </div>
                 </div>
                 {% endfor %}
@@ -155,19 +177,44 @@
                         <h5 class="card-title mb-2"><span class="badge badge-os">OS {{ os_sp.os }}</span> Frota {{ os_sp.frota }}</h5>
                         <p class="card-text"><small class="text-muted">Abertura: {{ os_sp.data_entrada }} (Aberta há {{ os_sp.dias_abertos }} dias)</small></p>
                         <p class="card-text">{{ os_sp.servico }}</p>
-                        <form action="{{ url_for('atribuir_prestador', os_numero_str=os_sp.os) }}" method="POST" class="mt-3">
-                            <div class="input-group">
-                                <select class="form-select" name="prestador_usuario" required>
-                                    <option value="" selected disabled>Selecione um prestador...</option>
-                                    {% for p in prestadores_disponiveis %}
-                                        {% if p.tipo != 'manutencao' %}
-                                        <option value="{{ p.usuario }}">{{ p.nome_exibicao|capitalize_name }}</option>
-                                        {% endif %}
-                                    {% endfor %}
-                                </select>
-                                <button class="btn btn-agro" type="submit">Atribuir</button>
+                        <hr>
+                        <div class="row">
+                            <div class="col-md-6">
+                                <h6 class="text-muted">Opção 1: Atribuir</h6>
+                                <form action="{{ url_for('atribuir_prestador', os_numero_str=os_sp.os) }}" method="POST" class="mt-2">
+                                    <div class="input-group">
+                                        <select class="form-select" name="prestador_usuario" required>
+                                            <option value="" selected disabled>Selecione um prestador...</option>
+                                            {% for p in prestadores_disponiveis %}
+                                                {% if p.tipo != 'manutencao' %}
+                                                <option value="{{ p.usuario }}">{{ p.nome_exibicao|capitalize_name }}</option>
+                                                {% endif %}
+                                            {% endfor %}
+                                        </select>
+                                        <button class="btn btn-primary btn-sm" type="submit">Atribuir</button>
+                                    </div>
+                                </form>
                             </div>
-                        </form>
+                            <div class="col-md-6">
+                                <h6 class="text-muted">Opção 2: Finalizar</h6>
+                                <div class="finalize-section">
+                                    <form action="{{ url_for('finalizar_os', os_numero_str=os_sp.os) }}" method="POST">
+                                        <div class="row g-2 mb-2">
+                                            <div class="col-md-6">
+                                                <input type="date" class="form-control form-control-sm" name="data_finalizacao" required max="{{ today_date }}" placeholder="Data">
+                                            </div>
+                                            <div class="col-md-6">
+                                                <input type="time" class="form-control form-control-sm" name="hora_finalizacao" required placeholder="Hora">
+                                            </div>
+                                        </div>
+                                        <div class="mt-2">
+                                            <textarea class="form-control form-control-sm" name="observacoes" rows="1" placeholder="Observações..."></textarea>
+                                        </div>
+                                        <button type="submit" class="btn btn-agro btn-sm w-100 mt-2">Finalizar OS</button>
+                                    </form>
+                                </div>
+                            </div>
+                        </div>
                     </div>
                 </div>
                 {% endfor %}


### PR DESCRIPTION
This commit fixes a bug where the 'Atribuir OS' tab on the maintenance panel was incorrectly showing zero unassigned OS. The `carregar_os_sem_prestador` function has been simplified to correctly fetch all OS without a provider, removing the faulty filtering logic.

Additionally, the UX has been improved by adding the finalization form to the cards in the 'Atribuir OS' tab. This allows maintenance users to either assign the OS to a provider or finalize it directly from the same view.