### PR TITLE
fix(maintenance): Correct mascot OS count and greeting logic

### DIFF
--- a/app.py
+++ b/app.py
@@ -138,8 +138,8 @@ GREETINGS = [
 ]
 
 @app.context_processor
-def inject_random_greeting():
-    return dict(random_greeting=random.choice(GREETINGS))
+def inject_greetings_list():
+    return dict(greetings_list=GREETINGS)
 
 # --- Models ---
 class User(db.Model):

--- a/templates/painel.html
+++ b/templates/painel.html
@@ -180,11 +180,20 @@
   <div class="mascot-container">
     <div class="mascot-icon">🚜</div>
     <div class="speech-bubble {{ bubble_class }}">
-      <h5 class="fw-bold mb-1">{{ random_greeting }} {{ gerente|capitalize_name }}!</h5>
+      <h5 class="fw-bold mb-1" id="greeting-text">{{ gerente|capitalize_name }}!</h5>
       <p class="mb-0">{{ message }}</p>
     </div>
   </div>
   {# --- Fim do Bloco de Saudação com Mascote --- #}
+
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+    const greetings = {{ greetings_list|tojson }};
+    const randomGreeting = greetings[Math.floor(Math.random() * greetings.length)];
+    const greetingElement = document.getElementById('greeting-text');
+    greetingElement.innerHTML = randomGreeting + ' ' + greetingElement.innerHTML;
+});
+</script>
 
   {% if os_pendentes %}
     {% for os in os_pendentes %}

--- a/templates/painel_manutencao.html
+++ b/templates/painel_manutencao.html
@@ -91,7 +91,7 @@
 <div class="container py-4">
 
     {# --- Bloco de Saudação com Mascote --- #}
-    {% set os_count = total_os + total_os_sem_prestador %}
+    {% set os_count = total_os %}
     {% if os_count == 0 %}
       {% set bubble_class = 'bubble-success' %}
       {% set message = 'Tudo limpo por aqui! Nenhuma OS para você. ✅' %}
@@ -103,11 +103,20 @@
     <div class="mascot-container">
         <div class="mascot-icon">🚜</div>
         <div class="speech-bubble {{ bubble_class }}">
-          <h5 class="fw-bold mb-1">{{ random_greeting }} {{ nome|capitalize_name }}!</h5>
+      <h5 class="fw-bold mb-1" id="greeting-text">{{ nome|capitalize_name }}!</h5>
           <p class="mb-0">{{ message }}</p>
         </div>
     </div>
     {# --- Fim do Bloco de Saudação com Mascote --- #}
+
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+    const greetings = {{ greetings_list|tojson }};
+    const randomGreeting = greetings[Math.floor(Math.random() * greetings.length)];
+    const greetingElement = document.getElementById('greeting-text');
+    greetingElement.innerHTML = randomGreeting + ' ' + greetingElement.innerHTML;
+});
+</script>
 
     <ul class="nav nav-tabs mb-3" id="manutencaoTabs" role="tablist">
         <li class="nav-item" role="presentation">

--- a/templates/painel_prestador.html
+++ b/templates/painel_prestador.html
@@ -156,11 +156,20 @@
     <div class="mascot-container">
         <div class="mascot-icon">🚜</div>
         <div class="speech-bubble {{ bubble_class }}">
-          <h5 class="fw-bold mb-1">{{ random_greeting }} {{ nome|capitalize_name }}!</h5>
+      <h5 class="fw-bold mb-1" id="greeting-text">{{ nome|capitalize_name }}!</h5>
           <p class="mb-0">{{ message }}</p>
         </div>
     </div>
     {# --- Fim do Bloco de Saudação com Mascote --- #}
+
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+    const greetings = {{ greetings_list|tojson }};
+    const randomGreeting = greetings[Math.floor(Math.random() * greetings.length)];
+    const greetingElement = document.getElementById('greeting-text');
+    greetingElement.innerHTML = randomGreeting + ' ' + greetingElement.innerHTML;
+});
+</script>
 
     {% if os_list %}
         {% for item in os_list %}


### PR DESCRIPTION
This commit fixes two issues with the mascot feature on the maintenance panel.

First, the OS count displayed in the mascot's speech bubble was incorrect. It now correctly reflects the count of OS directly assigned to the user (`total_os`), not a sum of multiple lists.

Second, the greeting randomization was not working reliably. The logic has been moved to the client side. The backend now provides the full list of greetings, and a JavaScript snippet on the page randomly selects one to display. This has been applied to all panels where the mascot appears for consistency.