### PR TITLE
Corrige os nomes de arquivos de Ordens de Serviço (OS) para vários pr…

### DIFF
--- a/prestadores.json
+++ b/prestadores.json
@@ -3,7 +3,7 @@
     "usuario": "rosalina",
     "nome_exibicao": "11 268 880 Rosalina Quintino Suett",
     "senha": "rosalina123",
-    "arquivo_os": "11.268.880_ROSALINA_QUINTINO_SUETT.json"
+    "arquivo_os": "11_268_880_ROSALINA_QUINTINO_SUETT.json"
   },
   {
     "usuario": "anderson",
@@ -21,7 +21,7 @@
     "usuario": "cocamar",
     "nome_exibicao": "Cocamar Maquinas Agricolas Ltda ",
     "senha": "cocamar123",
-    "arquivo_os": "COCAMAR_MAQUINAS_AGRICOLAS_LTDA..json"
+    "arquivo_os": "COCAMAR_MAQUINAS_AGRICOLAS_LTDA.json"
   },
   {
     "usuario": "comercial",
@@ -33,13 +33,13 @@
     "usuario": "darci",
     "nome_exibicao": "Darci Capel & Cia Ltda",
     "senha": "darci123",
-    "arquivo_os": "DARCI_CAPEL_&_CIA_LTDA.json"
+    "arquivo_os": "DARCI_CAPEL_CIA_LTDA.json"
   },
   {
     "usuario": "equagril",
     "nome_exibicao": "Equagril Equipamentos Agricolas Umuar",
     "senha": "equagril123",
-    "arquivo_os": "EQUAGRIL_EQUIPAMENTOS_AGRICOLAS_-_UMUAR.json"
+    "arquivo_os": "EQUAGRIL_EQUIPAMENTOS_AGRICOLAS_LTDA.json"
   },
   {
     "usuario": "fernanda",
@@ -75,7 +75,7 @@
     "usuario": "injecoes",
     "nome_exibicao": "Injecoes Diesel Noroeste Ltda ",
     "senha": "injecoes123",
-    "arquivo_os": "INJECOES_DIESEL_NOROESTE_LTDA..json"
+    "arquivo_os": "INJECOES_DIESEL_NOROESTE_LTDA.json"
   },
   {
     "usuario": "jocar",
@@ -123,7 +123,7 @@
     "usuario": "pedro",
     "nome_exibicao": "Pedro Pereira Montessani Eireli Me",
     "senha": "pedro123",
-    "arquivo_os": "PEDRO_PEREIRA_MONTESSANI_EIRELI_-_ME.json"
+    "arquivo_os": "PEDRO_PEREIRA_MONTESSANI_EIRELI_ME.json"
   },
   {
     "usuario": "rivelino",


### PR DESCRIPTION
…estadores no arquivo `prestadores.json`.

O problema ocorria porque os valores no campo `arquivo_os` continham erros de digitação (hífens, pontos extras, etc.) que impediam o sistema de encontrar os arquivos JSON correspondentes. Isso fazia com que a contagem de OS para esses prestadores aparecesse como zerada.

Esta correção alinha os nomes dos arquivos no `prestadores.json` com os nomes reais dos arquivos no diretório `mensagens_por_prestador`, resolvendo o bug para todos os prestadores afetados.