### PR TITLE
feat: Add lubrication plan management system

### DIFF
--- a/templates/lub_plano_detalhe.html
+++ b/templates/lub_plano_detalhe.html
@@ -1,0 +1,185 @@
+{% extends "base.html" %}
+
+{% block title %}Detalhes do Plano: {{ plano.nome_plano }}{% endblock %}
+
+{% block page_title %}
+<a href="{{ url_for('painel_lubrificacao') }}" class="text-decoration-none text-dark">Planos de Lubrificação</a>
+<i class="fas fa-angle-right mx-2"></i>
+{{ plano.nome_plano }}
+{% endblock %}
+
+{% block content %}
+<div class="container py-4">
+    <div class="card mb-4">
+        <div class="card-header">
+            <h4 class="mb-0">Detalhes do Plano</h4>
+        </div>
+        <div class="card-body">
+            <p><strong>Nome do Plano:</strong> {{ plano.nome_plano }}</p>
+            <p><strong>Modelo do Veículo:</strong> {{ plano.modelo_veiculo }}</p>
+        </div>
+    </div>
+
+    <div class="card">
+        <div class="card-header">
+            <h4 class="mb-0">Revisões do Plano</h4>
+        </div>
+        <div class="card-body">
+            <!-- Formulário para Adicionar Nova Revisão -->
+            <div class="mb-4 p-3 border rounded bg-light">
+                <h5>Adicionar Nova Revisão</h5>
+                <form action="{{ url_for('add_lub_revisao', plano_id=plano.id) }}" method="POST" class="row g-3 align-items-end">
+                    <div class="col-md-8">
+                        <label for="nome_revisao" class="form-label">Nome da Revisão</label>
+                        <input type="text" class="form-control" id="nome_revisao" name="nome_revisao" placeholder="Ex: Revisão 400h" required>
+                    </div>
+                    <div class="col-md-4">
+                        <button type="submit" class="btn btn-success w-100">
+                            <i class="fas fa-plus-circle me-1"></i> Adicionar Revisão
+                        </button>
+                    </div>
+                </form>
+            </div>
+
+            <!-- Lista de Revisões Existentes -->
+            <div class="accordion" id="accordionRevisoes">
+                {% for revisao in plano.revisoes|sort(attribute='nome_revisao') %}
+                <div class="accordion-item">
+                    <h2 class="accordion-header" id="heading-revisao-{{ revisao.id }}">
+                        <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapse-revisao-{{ revisao.id }}" aria-expanded="false" aria-controls="collapse-revisao-{{ revisao.id }}">
+                            <strong>{{ revisao.nome_revisao }}</strong>
+                        </button>
+                    </h2>
+                    <div id="collapse-revisao-{{ revisao.id }}" class="accordion-collapse collapse" data-bs-parent="#accordionRevisoes">
+                        <div class="accordion-body">
+                            <div class="d-flex justify-content-end mb-3">
+                                <form action="{{ url_for('delete_lub_revisao', revisao_id=revisao.id) }}" method="POST" onsubmit="return confirm('Tem certeza que deseja remover esta revisão e todos os seus itens?');">
+                                    <button type="submit" class="btn btn-sm btn-danger">
+                                        <i class="fas fa-trash-alt me-1"></i> Remover Revisão
+                                    </button>
+                                </form>
+                            </div>
+
+                            <h6>Itens da Revisão</h6>
+                            <table class="table table-bordered table-striped">
+                                <thead class="table-light">
+                                    <tr>
+                                        <th>Sistema</th>
+                                        <th>Subsistema</th>
+                                        <th>Componente (Código PIMNS)</th>
+                                        <th>Ação</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    {% for item in revisao.itens %}
+                                    <tr>
+                                        <td>{{ item.subsistema.sistema.nome }}</td>
+                                        <td>{{ item.subsistema.nome }}</td>
+                                        <td>{{ item.componente.nome }} ({{ item.componente.codigo_pimns }})</td>
+                                        <td>
+                                            <form action="{{ url_for('delete_lub_item_revisao', item_id=item.id) }}" method="POST">
+                                                <button type="submit" class="btn btn-sm btn-outline-danger" title="Remover Item">
+                                                    <i class="fas fa-times"></i>
+                                                </button>
+                                            </form>
+                                        </td>
+                                    </tr>
+                                    {% else %}
+                                    <tr>
+                                        <td colspan="4" class="text-center text-muted">Nenhum item adicionado a esta revisão.</td>
+                                    </tr>
+                                    {% endfor %}
+                                </tbody>
+                            </table>
+
+                            <hr class="my-4">
+
+                            <h6>Adicionar Novo Item à Revisão</h6>
+                            <form action="{{ url_for('add_lub_item_revisao', revisao_id=revisao.id) }}" method="POST" class="p-3 border rounded bg-light">
+                                <div class="row g-3">
+                                    <div class="col-md-4">
+                                        <label class="form-label">Sistema</label>
+                                        <select class="form-select sistema-select" data-revisao-id="{{ revisao.id }}" required>
+                                            <option value="" selected disabled>Selecione...</option>
+                                            {% for sistema in sistemas %}
+                                            <option value="{{ sistema.id }}">{{ sistema.nome }}</option>
+                                            {% endfor %}
+                                        </select>
+                                    </div>
+                                    <div class="col-md-4">
+                                        <label class="form-label">Subsistema</label>
+                                        <select class="form-select subsistema-select" name="subsistema_id" id="subsistema-select-{{ revisao.id }}" required>
+                                            <option value="" selected disabled>Selecione um sistema primeiro</option>
+                                        </select>
+                                    </div>
+                                    <div class="col-md-4">
+                                        <label class="form-label">Componente</label>
+                                        <select class="form-select" name="componente_id" required>
+                                            <option value="" selected disabled>Selecione...</option>
+                                            {% for comp in componentes|sort(attribute='nome') %}
+                                            <option value="{{ comp.id }}">{{ comp.nome }} ({{ comp.codigo_pimns }})</option>
+                                            {% endfor %}
+                                        </select>
+                                    </div>
+                                    <div class="col-12 d-grid">
+                                        <button type="submit" class="btn btn-primary mt-2">
+                                            <i class="fas fa-plus-circle me-1"></i> Adicionar Item
+                                        </button>
+                                    </div>
+                                </div>
+                            </form>
+                        </div>
+                    </div>
+                </div>
+                {% else %}
+                <div class="text-center p-3 text-muted">
+                    Nenhuma revisão cadastrada para este plano.
+                </div>
+                {% endfor %}
+            </div>
+        </div>
+    </div>
+</div>
+
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+    const sistemaSelects = document.querySelectorAll('.sistema-select');
+
+    sistemaSelects.forEach(select => {
+        select.addEventListener('change', function() {
+            const sistemaId = this.value;
+            const revisaoId = this.dataset.revisaoId;
+            const subsistemaSelect = document.getElementById(`subsistema-select-${revisaoId}`);
+
+            subsistemaSelect.innerHTML = '<option value="" selected disabled>Carregando...</option>';
+
+            if (!sistemaId) {
+                subsistemaSelect.innerHTML = '<option value="" selected disabled>Selecione um sistema primeiro</option>';
+                return;
+            }
+
+            fetch(`/api/subsistemas/${sistemaId}`)
+                .then(response => {
+                    if (!response.ok) {
+                        throw new Error('Network response was not ok');
+                    }
+                    return response.json();
+                })
+                .then(data => {
+                    subsistemaSelect.innerHTML = '<option value="" selected disabled>Selecione um subsistema</option>';
+                    data.forEach(subsistema => {
+                        const option = document.createElement('option');
+                        option.value = subsistema.id;
+                        option.textContent = subsistema.nome;
+                        subsistemaSelect.appendChild(option);
+                    });
+                })
+                .catch(error => {
+                    console.error('Erro ao buscar subsistemas:', error);
+                    subsistemaSelect.innerHTML = '<option value="" selected disabled>Erro ao carregar</option>';
+                });
+        });
+    });
+});
+</script>
+{% endblock %}

--- a/templates/lubrificacao.html
+++ b/templates/lubrificacao.html
@@ -1,0 +1,164 @@
+{% extends "base.html" %}
+
+{% block title %}Planos de Lubrificação{% endblock %}
+
+{% block page_title %}Gerenciamento de Planos de Lubrificação{% endblock %}
+
+{% block content %}
+<div class="container py-4">
+    <!-- Abas de Navegação -->
+    <ul class="nav nav-tabs mb-4" id="lubrificacaoTabs" role="tablist">
+        <li class="nav-item" role="presentation">
+            <button class="nav-link" id="planos-tab" data-bs-toggle="tab" data-bs-target="#planos" type="button" role="tab" aria-controls="planos" aria-selected="true">
+                <i class="fas fa-clipboard-list me-1"></i> Planos
+            </button>
+        </li>
+        <li class="nav-item" role="presentation">
+            <button class="nav-link active" id="componentes-tab" data-bs-toggle="tab" data-bs-target="#componentes" type="button" role="tab" aria-controls="componentes" aria-selected="false">
+                <i class="fas fa-cogs me-1"></i> Componentes
+            </button>
+        </li>
+        <li class="nav-item" role="presentation">
+            <button class="nav-link" id="sistemas-tab" data-bs-toggle="tab" data-bs-target="#sistemas" type="button" role="tab" aria-controls="sistemas" aria-selected="false">
+                <i class="fas fa-sitemap me-1"></i> Sistemas e Subsistemas
+            </button>
+        </li>
+    </ul>
+
+    <!-- Conteúdo das Abas -->
+    <div class="tab-content" id="lubrificacaoTabContent">
+        <!-- Aba de Planos -->
+        <div class="tab-pane fade" id="planos" role="tabpanel" aria-labelledby="planos-tab">
+            <div class="row">
+                <div class="col-md-4">
+                    <h5>Criar Novo Plano</h5>
+                    <div class="card">
+                        <div class="card-body">
+                            <form action="{{ url_for('add_lub_plano') }}" method="POST">
+                                <div class="mb-3">
+                                    <label for="nome_plano" class="form-label">Nome do Plano</label>
+                                    <input type="text" class="form-control" id="nome_plano" name="nome_plano" placeholder="Ex: Plano JD 5080E" required>
+                                </div>
+                                <div class="mb-3">
+                                    <label for="modelo_veiculo" class="form-label">Modelo do Veículo</label>
+                                    <input type="text" class="form-control" id="modelo_veiculo" name="modelo_veiculo" placeholder="Ex: JD 5080E" required>
+                                </div>
+                                <div class="d-grid">
+                                    <button type="submit" class="btn btn-primary">
+                                        <i class="fas fa-plus-circle me-1"></i> Criar Plano
+                                    </button>
+                                </div>
+                            </form>
+                        </div>
+                    </div>
+                </div>
+                <div class="col-md-8">
+                    <h5>Planos Existentes</h5>
+                    <div class="list-group">
+                        {% if planos %}
+                            {% for plano in planos %}
+                            <div class="list-group-item d-flex justify-content-between align-items-center">
+                                <a href="{{ url_for('lub_plano_detalhe', plano_id=plano.id) }}" class="text-decoration-none flex-grow-1">
+                                    <strong>{{ plano.nome_plano }}</strong>
+                                    <small class="text-muted d-block">Modelo: {{ plano.modelo_veiculo }}</small>
+                                </a>
+                                <form action="{{ url_for('delete_lub_plano', plano_id=plano.id) }}" method="POST" onsubmit="return confirm('Tem certeza que deseja remover este plano e todas as suas revisões?');">
+                                    <button type="submit" class="btn btn-sm btn-outline-danger ms-3">
+                                        <i class="fas fa-trash-alt"></i>
+                                    </button>
+                                </form>
+                            </div>
+                            {% endfor %}
+                        {% else %}
+                            <div class="list-group-item text-center text-muted">
+                                Nenhum plano de lubrificação cadastrado.
+                            </div>
+                        {% endif %}
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <!-- Aba de Componentes -->
+        <div class="tab-pane fade show active" id="componentes" role="tabpanel" aria-labelledby="componentes-tab">
+            <div class="row">
+                <div class="col-md-4">
+                    <h5>Adicionar Novo Componente</h5>
+                    <div class="card">
+                        <div class="card-body">
+                            <form action="{{ url_for('add_lub_componente') }}" method="POST">
+                                <div class="mb-3">
+                                    <label for="codigo_pimns" class="form-label">Código PIMNS</label>
+                                    <input type="text" class="form-control" id="codigo_pimns" name="codigo_pimns" required>
+                                </div>
+                                <div class="mb-3">
+                                    <label for="nome" class="form-label">Nome do Componente</label>
+                                    <input type="text" class="form-control" id="nome" name="nome" required>
+                                </div>
+                                <div class="d-grid">
+                                    <button type="submit" class="btn btn-primary">
+                                        <i class="fas fa-plus-circle me-1"></i> Adicionar
+                                    </button>
+                                </div>
+                            </form>
+                        </div>
+                    </div>
+                </div>
+                <div class="col-md-8">
+                    <h5>Componentes Cadastrados</h5>
+                    <div class="list-group" style="max-height: 400px; overflow-y: auto;">
+                        {% if componentes %}
+                            {% for comp in componentes %}
+                            <div class="list-group-item d-flex justify-content-between align-items-center">
+                                <div>
+                                    <strong class="text-primary">[{{ comp.codigo_pimns }}]</strong> {{ comp.nome }}
+                                </div>
+                                <form action="{{ url_for('delete_lub_componente', componente_id=comp.id) }}" method="POST" onsubmit="return confirm('Tem certeza que deseja remover este componente?');">
+                                    <button type="submit" class="btn btn-sm btn-outline-danger">
+                                        <i class="fas fa-trash-alt"></i>
+                                    </button>
+                                </form>
+                            </div>
+                            {% endfor %}
+                        {% else %}
+                            <div class="list-group-item text-center text-muted">
+                                Nenhum componente cadastrado ainda.
+                            </div>
+                        {% endif %}
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <!-- Aba de Sistemas e Subsistemas -->
+        <div class="tab-pane fade" id="sistemas" role="tabpanel" aria-labelledby="sistemas-tab">
+            <h5>Sistemas e Subsistemas Base</h5>
+            <p class="text-muted">Estes são os dados base do sistema. Para alterá-los, um administrador precisa modificar a configuração inicial.</p>
+            <div class="accordion" id="accordionSistemas">
+                {% for sistema in sistemas %}
+                <div class="accordion-item">
+                    <h2 class="accordion-header" id="heading-{{ sistema.id }}">
+                        <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapse-{{ sistema.id }}" aria-expanded="false" aria-controls="collapse-{{ sistema.id }}">
+                            <strong>{{ sistema.nome }}</strong>
+                        </button>
+                    </h2>
+                    <div id="collapse-{{ sistema.id }}" class="accordion-collapse collapse" aria-labelledby="heading-{{ sistema.id }}" data-bs-parent="#accordionSistemas">
+                        <div class="accordion-body">
+                            <ul class="list-group">
+                                {% for subsistema in sistema.subsistemas %}
+                                <li class="list-group-item">{{ subsistema.nome }}</li>
+                                {% else %}
+                                <li class="list-group-item text-muted">Nenhum subsistema cadastrado.</li>
+                                {% endfor %}
+                            </ul>
+                        </div>
+                    </div>
+                </div>
+                {% else %}
+                <div class="alert alert-warning">Nenhum sistema base foi encontrado.</div>
+                {% endfor %}
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/templates/painel_manutencao.html
+++ b/templates/painel_manutencao.html
@@ -154,6 +154,11 @@
                 <i class="fas fa-history me-1"></i>Histórico Geral
             </button>
         </li>
+        <li class="nav-item">
+          <a class="nav-link" href="{{ url_for('painel_lubrificacao') }}">
+            <i class="fas fa-oil-can me-1"></i> Planos de Lubrificação
+          </a>
+        </li>
     </ul>
 
     <div class="tab-content" id="manutencaoTabContent">


### PR DESCRIPTION
This commit introduces a new feature for managing vehicle fleet lubrication plans.

It includes:
- New database models for Systems, Subsystems, Components, Plans, Revisions, and Revision Items.
- A new user interface under "/lubrificacao" for full CRUD management of lubrication plans and their components.
- An API endpoint to support dynamic dropdowns in the UI for a better user experience.
- Seeding of initial system and subsystem data on application startup.