### PR TITLE
feat: Add link to lubrication plans on admin panel

### DIFF
--- a/templates/admin.html
+++ b/templates/admin.html
@@ -11,6 +11,9 @@
   <a href="{{ url_for('frota_leve') }}" class="btn btn-info btn-sm ms-2">
     <i class="fas fa-car-side me-1"></i>Frota Leve
   </a>
+  <a href="{{ url_for('painel_lubrificacao') }}" class="btn btn-secondary btn-sm ms-2">
+    <i class="fas fa-oil-can me-1"></i>Planos de Lubrificação
+  </a>
 {% endblock %}
 
 


### PR DESCRIPTION
Adds a direct link to the "Planos de Lubrificação" page from the header of the admin panel.

This provides easier access for administrators, as requested in user feedback. The link is placed next to the "Frota Leve" button for consistency.