### PR TITLE
fix: Handle schema migration for frota column rename

### DIFF
--- a/app.py
+++ b/app.py
@@ -377,6 +377,16 @@ def init_db():
             # Adiciona colunas detalhadas à tabela frota_veiculo se não existirem
             if 'frota_veiculo' in inspector.get_table_names():
                 columns_frota = [col['name'] for col in inspector.get_columns('frota_veiculo')]
+
+                # Renomeia a coluna se o nome antigo ainda existir
+                if 'tag_veiculo' in columns_frota and 'frota' not in columns_frota:
+                    logger.info("Renomeando coluna de 'tag_veiculo' para 'frota'")
+                    db.session.execute(text('ALTER TABLE frota_veiculo RENAME COLUMN tag_veiculo TO frota'))
+                    db.session.commit()
+                    logger.info("Coluna 'frota' renomeada com sucesso.")
+                    # Refresh columns list after rename
+                    columns_frota = [col['name'] for col in inspector.get_columns('frota_veiculo')]
+
                 new_cols = {
                     'fazenda': 'VARCHAR(100)',
                     'descricao': 'TEXT',


### PR DESCRIPTION
This commit fixes a critical 'UndefinedColumn' error that occurred when accessing the /frota page. The error was due to a mismatch between the application code, which expected a column named 'frota', and the database schema, which still had the old column name 'tag_veiculo'.

- Adds migration logic to `init_db` to automatically rename the database column from `tag_veiculo` to `frota` on application startup if the old column exists.
- Restores the production version of the `frota_index` route, removing any temporary debugging code.