### PR TITLE
feat: Add PDF report for manager OS

### DIFF
--- a/app.py
+++ b/app.py
@@ -1416,7 +1416,13 @@ def gerar_relatorio_pdf_gerente(manager_name):
 
 @app.route('/relatorio/pdf/<manager_name>')
 def download_relatorio_pdf(manager_name):
-    if not session.get('is_admin'):
+    is_authorized = False
+    if session.get('is_admin'):
+        is_authorized = True
+    elif session.get('gerente') and session.get('gerente').split('.')[0].lower() == manager_name.lower():
+        is_authorized = True
+
+    if not is_authorized:
         flash('Acesso negado', 'danger')
         return redirect(url_for('login'))
 

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -490,18 +490,18 @@
           </thead>
           <tbody>
             {% for gerente, count in ranking_os_abertas %}
-            {% if gerente.lower() in ['arthur.sousa', 'mauricio.jose'] %}
             <tr class="{% if loop.index > 3 %}gerente-ranking-row hidden-row{% endif %}">
               <td><span class="badge badge-ranking {% if loop.index == 1 %}ranking-1{% elif loop.index == 2 %}ranking-2{% elif loop.index == 3 %}ranking-3{% else %}ranking-other{% endif %}">{{ loop.index }}º</span></td>
               <td>{{ gerente|capitalize_name }}</td>
               <td>{{ count }} pendente{{ 's' if count != 1 else '' }}</td>
               <td>
+                {% if gerente.lower() in ['arthur.sousa', 'mauricio.jose'] %}
                 <a href="{{ url_for('download_relatorio_pdf', manager_name=gerente.split('.')[0]) }}" class="btn btn-agro btn-sm">
                   <i class="fas fa-file-pdf me-1"></i>
                 </a>
+                {% endif %}
               </td>
             </tr>
-            {% endif %}
             {% endfor %}
             {% if not ranking_os_abertas %}
             <tr><td colspan="3" class="text-center py-3">Nenhuma OS pendente</td></tr>

--- a/templates/painel.html
+++ b/templates/painel.html
@@ -8,6 +8,11 @@
     {% if profile_picture %}
         <img src="{{ profile_picture }}" alt="Foto de Perfil" class="rounded-circle" style="width: 40px; height: 40px; object-fit: cover;">
     {% endif %}
+    {% if session.get('gerente') in ['arthur.sousa', 'mauricio.jose'] %}
+    <a href="{{ url_for('download_relatorio_pdf', manager_name=session.get('gerente').split('.')[0]) }}" class="btn btn-info btn-sm ms-2">
+      <i class="fas fa-file-pdf me-1"></i> Relatório PDF
+    </a>
+    {% endif %}
     {% if session.get('is_admin') %}
     <a href="{{ url_for('admin_panel') }}" class="btn btn-admin btn-sm ms-2">
       <i class="fas fa-cog me-1"></i> Painel Admin


### PR DESCRIPTION
This commit introduces a new feature that allows administrators and managers to download a PDF report of open service orders (OS).

- Adds a new Flask route `/relatorio/pdf/<manager_name>` to generate and serve the PDF file.
- Implements the `gerar_relatorio_pdf_gerente` function using the `reportlab` library to create the PDF from the data in `static/json/relatorio_arthur.json` and `static/json/relatorio_mauricio.json`.
- Updates the `templates/admin.html` to include a download button for the relevant managers in the open OS ranking table, without filtering the other supervisors.
- Updates the `templates/painel.html` to include a download button for managers Mauricio and Arthur on their own dashboards.
- Updates `requirements.txt` with versions of `numpy`, `pandas`, and `psycopg2-binary` that are compatible with the Python 3.12 environment.